### PR TITLE
Fix black sky after returning to surface.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -43,21 +43,22 @@ minetest.register_globalstep(function(dtime)
 
 		local ndef = minetest.registered_nodes[head_node]
 
+		local current = player_list[name] or ""
+
+		-- noclip
 		if (ndef.walkable == nil or ndef.walkable == true)
 		and (ndef.drowning == nil or ndef.drowning == 0)
 		and (ndef.damage_per_second == nil or ndef.damage_per_second <= 0)
 		and (ndef.collision_box == nil or ndef.collision_box.type == "regular")
 		and (ndef.node_box == nil or ndef.node_box.type == "regular") then
-			player:set_sky({type = "regular"})
-			player:set_clouds({density = 0.4})
-			player_list[name] = "surface"
-			return
-		end
-
-		local current = player_list[name] or ""
+			if current ~= "noclip" then
+				player:set_sky({type = "regular"})
+				player:set_clouds({density = 0})
+				player_list[name] = "noclip"
+			end
 
 		-- Surface
-		if pos.y > sky_start and current ~= "surface" then
+		elseif pos.y > sky_start and current ~= "surface" then
 			player:set_sky({type = "regular"})
 			player:set_clouds({density = 0.4})
 			player_list[name] = "surface"

--- a/init.lua
+++ b/init.lua
@@ -34,7 +34,7 @@ minetest.register_globalstep(function(dtime)
 	for _, player in pairs(minetest.get_connected_players()) do
 
 		local name = player:get_player_name()
-		local pos = player:getpos()
+		local pos = player:get_pos()
 
 		pos.y = pos.y + 1.5 -- head level
 		local head_node = node_ok(pos)
@@ -48,8 +48,9 @@ minetest.register_globalstep(function(dtime)
 		and (ndef.damage_per_second == nil or ndef.damage_per_second <= 0)
 		and (ndef.collision_box == nil or ndef.collision_box.type == "regular")
 		and (ndef.node_box == nil or ndef.node_box.type == "regular") then
-			player:set_sky({}, "regular", {})
-			player_list[name] = "surface" 
+			player:set_sky({type = "regular"})
+			player:set_clouds({density = 0.4})
+			player_list[name] = "surface"
 			return
 		end
 
@@ -57,13 +58,13 @@ minetest.register_globalstep(function(dtime)
 
 		-- Surface
 		if pos.y > sky_start and current ~= "surface" then
-			player:set_sky({}, "regular", {})
+			player:set_sky({type = "regular"})
 			player:set_clouds({density = 0.4})
 			player_list[name] = "surface"
 
 		-- Everything else (blackness)
 		elseif pos.y < sky_start and current ~= "blackness" then
-			player:set_sky(000000, "plain", {})
+			player:set_sky({base_color = "#000000", type = "plain"})
 			player:set_clouds({density = 0})
 			player_list[name] = "blackness"
 		end


### PR DESCRIPTION
Using {} as first parameter of set_sky results in no change, nil should
have been used. Using new API removes the deprecated warnings.

Change getpos to get_pos to remove another deprecated warning.