### PR TITLE
Hide sun, moon, stars when underground

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
 
 local sky_start = tonumber(minetest.setting_get("sky_start") or -100)
 
-local player_list = {} 
+local player_list = {}
 
 local timer = 0
 
@@ -52,21 +52,18 @@ minetest.register_globalstep(function(dtime)
 		and (ndef.collision_box == nil or ndef.collision_box.type == "regular")
 		and (ndef.node_box == nil or ndef.node_box.type == "regular") then
 			if current ~= "noclip" then
-				player:set_sky({type = "regular"})
-				player:set_clouds({density = 0})
+				player:set_sky({ type = "regular", clouds = false })
 				player_list[name] = "noclip"
 			end
 
 		-- Surface
 		elseif pos.y > sky_start and current ~= "surface" then
-			player:set_sky({type = "regular"})
-			player:set_clouds({density = 0.4})
+			player:set_sky({ type = "regular", clouds = true })
 			player_list[name] = "surface"
 
 		-- Everything else (blackness)
 		elseif pos.y < sky_start and current ~= "blackness" then
-			player:set_sky({base_color = "#000000", type = "plain"})
-			player:set_clouds({density = 0})
+			player:set_sky({ base_color = "#000000", type = "plain", clouds = false })
 			player_list[name] = "blackness"
 		end
 	end

--- a/init.lua
+++ b/init.lua
@@ -53,17 +53,26 @@ minetest.register_globalstep(function(dtime)
 		and (ndef.node_box == nil or ndef.node_box.type == "regular") then
 			if current ~= "noclip" then
 				player:set_sky({ type = "regular", clouds = false })
+				player:set_sun({ visible = false, sunrise_visible = false })
+				player:set_moon({ visible = false })
+				player:set_stars({ visible = false })
 				player_list[name] = "noclip"
 			end
 
 		-- Surface
 		elseif pos.y > sky_start and current ~= "surface" then
 			player:set_sky({ type = "regular", clouds = true })
+			player:set_sun({ visible = true, sunrise_visible = true })
+			player:set_moon({ visible = true })
+			player:set_stars({ visible = true })
 			player_list[name] = "surface"
 
 		-- Everything else (blackness)
 		elseif pos.y < sky_start and current ~= "blackness" then
 			player:set_sky({ base_color = "#000000", type = "plain", clouds = false })
+			player:set_sun({ visible = false, sunrise_visible = false })
+			player:set_moon({ visible = false })
+			player:set_stars({ visible = false })
 			player_list[name] = "blackness"
 		end
 	end


### PR DESCRIPTION
A few more tweaks:

- Clouds are now hidden by using an on-purpose sky parameter rather than setting their density to zero. Solves the glitch that made some of them still visible while noclipping, even though the density was set to zero. It also won't collide with another mod that could possibly change the density value.

- Sun, moon, stars and the horizon sunrise halo were still visible while in the `blackness` state on certain circumstances: newly intriduced API helps. -- EDIT: see https://github.com/minetest/minetest/issues/10542.